### PR TITLE
Ignore cancel on new callback

### DIFF
--- a/lib/src/main/java/co/infinum/goldfinger/Clock.java
+++ b/lib/src/main/java/co/infinum/goldfinger/Clock.java
@@ -1,0 +1,28 @@
+package co.infinum.goldfinger;
+
+/**
+ * Singleton class that wraps time functions.
+ * It is mainly needed for tests.
+ */
+class Clock {
+
+    private static Clock INSTANCE;
+
+    private Clock() {
+    }
+
+    static Clock instance() {
+        if (INSTANCE == null) {
+            INSTANCE = new Clock();
+        }
+        return INSTANCE;
+    }
+
+    long currentTimeMs() {
+        return System.currentTimeMillis();
+    }
+
+    boolean isBeforeNow(long timeMs) {
+        return timeMs < currentTimeMs();
+    }
+}

--- a/lib/src/main/java/co/infinum/goldfinger/MarshmallowGoldfinger.java
+++ b/lib/src/main/java/co/infinum/goldfinger/MarshmallowGoldfinger.java
@@ -75,7 +75,7 @@ class MarshmallowGoldfinger implements Goldfinger {
         }
 
         logger.log("Starting authentication [keyName=%s; value=%s]", keyName, value);
-        cancellableAuthenticationCallback = new CancellableAuthenticationCallback(crypto, logger, mode, value, callback);
+        cancellableAuthenticationCallback = new CancellableAuthenticationCallback(crypto, logger, Clock.instance(), mode, value, callback);
         fingerprintManagerCompat.authenticate(cryptoObject,
                 0,
                 cancellableAuthenticationCallback.cancellationSignal,
@@ -86,7 +86,6 @@ class MarshmallowGoldfinger implements Goldfinger {
     @Override
     public void cancel() {
         if (cancellableAuthenticationCallback != null) {
-            mainHandler.removeCallbacksAndMessages(null);
             cancellableAuthenticationCallback.cancel();
             cancellableAuthenticationCallback = null;
         }


### PR DESCRIPTION
### General info
Issue happens when new `authentication` is started while last is still active which is pretty valid case. We ignore `Error.CANCELED` for first 100ms to avoid unnecessary `onError` callback on new authentication.

Fixes #20 