### PR TITLE
Fix user cancel error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+
+## Changelog
+
+### v1.1.2
+
+* Fix user cancel error. Exposed with a new enum value `Error.USER_CANCEL`
+* Lockout permanent error mapped to `Error.LOCKOUT`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 #### Add dependency
 
 ```gradle
-implementation 'co.infinum:goldfinger:1.1.1'
+implementation 'co.infinum:goldfinger:1.1.2'
 ```
 
 #### Initialize
@@ -50,8 +50,8 @@ Goldfinger has separate Rx module in case you want to use reactive approach.
 #### Add dependencies
 
 ```gradle
-implementation 'co.infinum:goldfinger:1.1.1'
-implementation 'co.infinum:goldfinger-rx:1.1.1'
+implementation 'co.infinum:goldfinger:1.1.2'
+implementation 'co.infinum:goldfinger-rx:1.1.2'
 ```
 
 #### Initialize

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ]
 
     ext.versions = [
-        goldfinger: '1.1.1',
+        goldfinger: '1.1.2',
         google    : '27.1.1',
         junit     : '4.12',
         mockito   : '2.10.0',

--- a/core/src/main/java/co/infinum/goldfinger/Error.java
+++ b/core/src/main/java/co/infinum/goldfinger/Error.java
@@ -59,6 +59,11 @@ public enum Error {
     ENCRYPTION_FAILED(true),
 
     /**
+     * User canceled fingerprint reading.
+     */
+    USER_CANCEL(false),
+
+    /**
      * The image acquired was good.
      */
     GOOD(false),
@@ -117,7 +122,10 @@ public enum Error {
             case FingerprintManager.FINGERPRINT_ERROR_CANCELED:
                 return CANCELED;
             case FingerprintManager.FINGERPRINT_ERROR_LOCKOUT:
+            case FingerprintManager.FINGERPRINT_ERROR_LOCKOUT_PERMANENT:
                 return LOCKOUT;
+            case FingerprintManager.FINGERPRINT_ERROR_USER_CANCELED:
+                return USER_CANCEL;
             default:
                 return UNKNOWN;
         }


### PR DESCRIPTION
Small fix to expose a user cancel action. 
I notice this on Samsung s10 where a user can cancel fingerprint reading. This device has an overlay while the device fingerprint reader is active. When the user dismisses this overlay the error occurs. Currently, this is a critical UNKNOWN error.

I prepared readme for a new version and added changelog since it is missing in the library.