### PR TITLE
Release/2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext.versions = [
         appcompat : '1.1.0',
-        biometric : '1.1.0-rc01',
+        biometric : '1.1.0',
         goldfinger: '2.0.1',
         junit     : '4.12',
         mockito   : '2.28.2',

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@ buildscript {
 
     ext.sdk = [
         min   : 14,
-        target: 29,
+        target: 30,
     ]
 
     ext.versions = [
         appcompat : '1.1.0',
-        biometric : '1.0.1',
+        biometric : '1.1.0-rc01',
         goldfinger: '2.0.1',
         junit     : '4.12',
         mockito   : '2.28.2',

--- a/core/src/main/java/co/infinum/goldfinger/EnumConverter.java
+++ b/core/src/main/java/co/infinum/goldfinger/EnumConverter.java
@@ -38,6 +38,8 @@ class EnumConverter {
                 return Goldfinger.Reason.NEGATIVE_BUTTON;
             case BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL:
                 return Goldfinger.Reason.NO_DEVICE_CREDENTIAL;
+            case BiometricPrompt.ERROR_SECURITY_UPDATE_REQUIRED:
+                return Goldfinger.Reason.SECURITY_UPDATE_REQUIRED;
             default:
                 return Goldfinger.Reason.UNKNOWN;
         }

--- a/core/src/main/java/co/infinum/goldfinger/EnumConverter.java
+++ b/core/src/main/java/co/infinum/goldfinger/EnumConverter.java
@@ -1,6 +1,6 @@
 package co.infinum.goldfinger;
 
-import androidx.biometric.BiometricConstants;
+import androidx.biometric.BiometricPrompt;
 
 /**
  * Internal class used to convert Biometric constants into meaningful enum.
@@ -12,31 +12,31 @@ class EnumConverter {
 
     static Goldfinger.Reason errorToReason(int errorId) {
         switch (errorId) {
-            case BiometricConstants.ERROR_HW_UNAVAILABLE:
+            case BiometricPrompt.ERROR_HW_UNAVAILABLE:
                 return Goldfinger.Reason.HARDWARE_UNAVAILABLE;
-            case BiometricConstants.ERROR_UNABLE_TO_PROCESS:
+            case BiometricPrompt.ERROR_UNABLE_TO_PROCESS:
                 return Goldfinger.Reason.UNABLE_TO_PROCESS;
-            case BiometricConstants.ERROR_TIMEOUT:
+            case BiometricPrompt.ERROR_TIMEOUT:
                 return Goldfinger.Reason.TIMEOUT;
-            case BiometricConstants.ERROR_NO_SPACE:
+            case BiometricPrompt.ERROR_NO_SPACE:
                 return Goldfinger.Reason.NO_SPACE;
-            case BiometricConstants.ERROR_CANCELED:
+            case BiometricPrompt.ERROR_CANCELED:
                 return Goldfinger.Reason.CANCELED;
-            case BiometricConstants.ERROR_LOCKOUT:
+            case BiometricPrompt.ERROR_LOCKOUT:
                 return Goldfinger.Reason.LOCKOUT;
-            case BiometricConstants.ERROR_VENDOR:
+            case BiometricPrompt.ERROR_VENDOR:
                 return Goldfinger.Reason.VENDOR;
-            case BiometricConstants.ERROR_LOCKOUT_PERMANENT:
+            case BiometricPrompt.ERROR_LOCKOUT_PERMANENT:
                 return Goldfinger.Reason.LOCKOUT_PERMANENT;
-            case BiometricConstants.ERROR_USER_CANCELED:
+            case BiometricPrompt.ERROR_USER_CANCELED:
                 return Goldfinger.Reason.USER_CANCELED;
-            case BiometricConstants.ERROR_NO_BIOMETRICS:
+            case BiometricPrompt.ERROR_NO_BIOMETRICS:
                 return Goldfinger.Reason.NO_BIOMETRICS;
-            case BiometricConstants.ERROR_HW_NOT_PRESENT:
+            case BiometricPrompt.ERROR_HW_NOT_PRESENT:
                 return Goldfinger.Reason.HW_NOT_PRESENT;
-            case BiometricConstants.ERROR_NEGATIVE_BUTTON:
+            case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
                 return Goldfinger.Reason.NEGATIVE_BUTTON;
-            case BiometricConstants.ERROR_NO_DEVICE_CREDENTIAL:
+            case BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL:
                 return Goldfinger.Reason.NO_DEVICE_CREDENTIAL;
             default:
                 return Goldfinger.Reason.UNKNOWN;

--- a/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
+++ b/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
@@ -580,6 +580,11 @@ public interface Goldfinger {
         NO_DEVICE_CREDENTIAL,
 
         /**
+         * @see BiometricPrompt#ERROR_SECURITY_UPDATE_REQUIRED
+         */
+        SECURITY_UPDATE_REQUIRED,
+
+        /**
          * Dispatched when Fingerprint authentication is initialized correctly and
          * just before actual authentication is started. Can be used to update UI if necessary.
          */

--- a/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
+++ b/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
@@ -281,9 +281,9 @@ public interface Goldfinger {
                 .setTitle(title)
                 .setSubtitle(subtitle)
                 .setDescription(description)
-                .setDeviceCredentialAllowed(deviceCredentialsAllowed)
+//                .setDeviceCredentialAllowed(deviceCredentialsAllowed)
                 .setAllowedAuthenticators(allowedAuthenticators)
-                .setNegativeButtonText(negativeButtonText)
+//                .setNegativeButtonText(negativeButtonText)
                 .setConfirmationRequired(confirmationRequired);
 
             return builder.build();
@@ -299,7 +299,7 @@ public interface Goldfinger {
             @Nullable private String title;
             private boolean confirmationRequired;
             private boolean deviceCredentialsAllowed;
-            private int allowedAuthenticators;
+            private int allowedAuthenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK;
 
             public Builder(@NonNull FragmentActivity activity) {
                 this.dialogOwner = activity;

--- a/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
+++ b/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
@@ -282,8 +282,8 @@ public interface Goldfinger {
                 .setSubtitle(subtitle)
                 .setDescription(description)
 //                .setDeviceCredentialAllowed(deviceCredentialsAllowed)
-                .setAllowedAuthenticators(allowedAuthenticators)
-//                .setNegativeButtonText(negativeButtonText)
+//                .setAllowedAuthenticators(allowedAuthenticators)
+                .setNegativeButtonText(negativeButtonText)
                 .setConfirmationRequired(confirmationRequired);
 
             return builder.build();

--- a/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
+++ b/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
@@ -103,7 +103,7 @@ public interface Goldfinger {
         @Nullable private CipherCrypter cipherCrypter;
         @Nullable private MacCrypter macCrypter;
         @Nullable private SignatureCrypter signatureCrypter;
-        @NonNull private Mode mode = Mode.AUTHENTICATION;
+        private int allowedAuthenticators;
         @Nullable private String key;
         @Nullable private String value;
 
@@ -210,6 +210,7 @@ public interface Goldfinger {
         @Nullable private final String title;
         private final boolean confirmationRequired;
         private final boolean deviceCredentialsAllowed;
+        private final int allowedAuthenticators;
 
         private PromptParams(
             @NonNull Object dialogOwner,
@@ -218,7 +219,8 @@ public interface Goldfinger {
             @Nullable String negativeButtonText,
             @Nullable String subtitle,
             boolean confirmationRequired,
-            boolean deviceCredentialsAllowed
+            boolean deviceCredentialsAllowed,
+            int allowedAuthenticators
         ) {
             this.dialogOwner = dialogOwner;
             this.title = title;
@@ -227,24 +229,22 @@ public interface Goldfinger {
             this.subtitle = subtitle;
             this.confirmationRequired = confirmationRequired;
             this.deviceCredentialsAllowed = deviceCredentialsAllowed;
-        }
-
-        public boolean confirmationRequired() {
-            return confirmationRequired;
-        }
-
-        @Nullable
-        public String description() {
-            return description;
-        }
-
-        public boolean deviceCredentialsAllowed() {
-            return deviceCredentialsAllowed;
+            this.allowedAuthenticators = allowedAuthenticators;
         }
 
         @NonNull
         public Object dialogOwner() {
             return dialogOwner;
+        }
+
+        @Nullable
+        public String title() {
+            return title;
+        }
+
+        @Nullable
+        public String description() {
+            return description;
         }
 
         @Nullable
@@ -257,9 +257,16 @@ public interface Goldfinger {
             return subtitle;
         }
 
-        @Nullable
-        public String title() {
-            return title;
+        public boolean confirmationRequired() {
+            return confirmationRequired;
+        }
+
+        public boolean deviceCredentialsAllowed() {
+            return deviceCredentialsAllowed;
+        }
+
+        public int allowedAuthenticators() {
+            return allowedAuthenticators;
         }
 
         /**
@@ -287,13 +294,13 @@ public interface Goldfinger {
 
             /* Dialog dialogOwner can be either Fragment or FragmentActivity */
             @NonNull private Object dialogOwner;
-            @NonNull private Mode mode = Mode.AUTHENTICATION;
             @Nullable private String description;
             @Nullable private String negativeButtonText;
             @Nullable private String subtitle;
             @Nullable private String title;
             private boolean confirmationRequired;
             private boolean deviceCredentialsAllowed;
+            private int allowedAuthenticators;
 
             public Builder(@NonNull FragmentActivity activity) {
                 this.dialogOwner = activity;
@@ -312,16 +319,26 @@ public interface Goldfinger {
                     negativeButtonText,
                     subtitle,
                     confirmationRequired,
-                    deviceCredentialsAllowed
+                    deviceCredentialsAllowed,
+                    allowedAuthenticators
                 );
             }
 
             /**
-             * @see BiometricPrompt.PromptInfo.Builder#setConfirmationRequired
+             * @see BiometricPrompt.PromptInfo.Builder#setTitle
              */
             @NonNull
-            public Builder confirmationRequired(boolean confirmationRequired) {
-                this.confirmationRequired = confirmationRequired;
+            public Builder title(@NonNull String title) {
+                this.title = title;
+                return this;
+            }
+
+            /**
+             * @see BiometricPrompt.PromptInfo.Builder#setTitle
+             */
+            @NonNull
+            public Builder title(@StringRes int resId) {
+                this.title = getString(resId);
                 return this;
             }
 
@@ -340,15 +357,6 @@ public interface Goldfinger {
             @NonNull
             public Builder description(@StringRes int resId) {
                 this.description = getString(resId);
-                return this;
-            }
-
-            /**
-             * @see BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed
-             */
-            @NonNull
-            public Builder deviceCredentialsAllowed(boolean deviceCredentialsAllowed) {
-                this.deviceCredentialsAllowed = deviceCredentialsAllowed;
                 return this;
             }
 
@@ -389,20 +397,30 @@ public interface Goldfinger {
             }
 
             /**
-             * @see BiometricPrompt.PromptInfo.Builder#setTitle
+             * @see BiometricPrompt.PromptInfo.Builder#setConfirmationRequired
              */
             @NonNull
-            public Builder title(@NonNull String title) {
-                this.title = title;
+            public Builder confirmationRequired(boolean confirmationRequired) {
+                this.confirmationRequired = confirmationRequired;
                 return this;
             }
 
             /**
-             * @see BiometricPrompt.PromptInfo.Builder#setTitle
+             * @see BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed
              */
             @NonNull
-            public Builder title(@StringRes int resId) {
-                this.title = getString(resId);
+            public Builder deviceCredentialsAllowed(boolean deviceCredentialsAllowed) {
+                this.deviceCredentialsAllowed = deviceCredentialsAllowed;
+                return this;
+            }
+
+
+            /**
+             * @see BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed
+             */
+            @NonNull
+            public Builder allowedAuthenticators(boolean deviceCredentialsAllowed) {
+                this.deviceCredentialsAllowed = deviceCredentialsAllowed;
                 return this;
             }
 

--- a/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
+++ b/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
@@ -103,7 +103,6 @@ public interface Goldfinger {
         @Nullable private CipherCrypter cipherCrypter;
         @Nullable private MacCrypter macCrypter;
         @Nullable private SignatureCrypter signatureCrypter;
-        private int allowedAuthenticators;
         @Nullable private String key;
         @Nullable private String value;
 
@@ -281,8 +280,7 @@ public interface Goldfinger {
                 .setTitle(title)
                 .setSubtitle(subtitle)
                 .setDescription(description)
-//                .setDeviceCredentialAllowed(deviceCredentialsAllowed)
-//                .setAllowedAuthenticators(allowedAuthenticators)
+                .setAllowedAuthenticators(allowedAuthenticators)
                 .setNegativeButtonText(negativeButtonText)
                 .setConfirmationRequired(confirmationRequired);
 
@@ -298,7 +296,6 @@ public interface Goldfinger {
             @Nullable private String subtitle;
             @Nullable private String title;
             private boolean confirmationRequired;
-            private boolean deviceCredentialsAllowed;
             private int allowedAuthenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK;
 
             public Builder(@NonNull FragmentActivity activity) {
@@ -311,6 +308,8 @@ public interface Goldfinger {
 
             @NonNull
             public PromptParams build() {
+                boolean deviceCredentialAllowed = (allowedAuthenticators & BiometricManager.Authenticators.DEVICE_CREDENTIAL) != 0;
+
                 return new PromptParams(
                     dialogOwner,
                     title,
@@ -318,7 +317,7 @@ public interface Goldfinger {
                     negativeButtonText,
                     subtitle,
                     confirmationRequired,
-                    deviceCredentialsAllowed,
+                    deviceCredentialAllowed,
                     allowedAuthenticators
                 );
             }
@@ -401,17 +400,6 @@ public interface Goldfinger {
             @NonNull
             public Builder confirmationRequired(boolean confirmationRequired) {
                 this.confirmationRequired = confirmationRequired;
-                return this;
-            }
-
-            /**
-             * @see BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed
-             * @deprecated Use {@link #allowedAuthenticators(int)} instead.
-             */
-            @NonNull
-            @Deprecated
-            public Builder deviceCredentialsAllowed(boolean deviceCredentialsAllowed) {
-                this.deviceCredentialsAllowed = deviceCredentialsAllowed;
                 return this;
             }
 

--- a/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
+++ b/core/src/main/java/co/infinum/goldfinger/Goldfinger.java
@@ -26,17 +26,17 @@ public interface Goldfinger {
     /**
      * Returns true if user has fingerprint hardware, false otherwise.
      */
-    boolean hasFingerprintHardware();
+    boolean hasFingerprintHardware(int authenticators);
 
     /**
      * Returns true if user has enrolled fingerprint, false otherwise.
      */
-    boolean hasEnrolledFingerprint();
+    boolean hasEnrolledFingerprint(int authenticators);
 
     /**
-     * @see BiometricManager#canAuthenticate()
+     * @see BiometricManager#canAuthenticate(int)
      */
-    boolean canAuthenticate();
+    boolean canAuthenticate(int authenticators);
 
     /**
      * Authenticate user via Fingerprint.
@@ -282,11 +282,10 @@ public interface Goldfinger {
                 .setSubtitle(subtitle)
                 .setDescription(description)
                 .setDeviceCredentialAllowed(deviceCredentialsAllowed)
+                .setAllowedAuthenticators(allowedAuthenticators)
+                .setNegativeButtonText(negativeButtonText)
                 .setConfirmationRequired(confirmationRequired);
 
-            if (!deviceCredentialsAllowed) {
-                builder.setNegativeButtonText(negativeButtonText);
-            }
             return builder.build();
         }
 
@@ -407,20 +406,21 @@ public interface Goldfinger {
 
             /**
              * @see BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed
+             * @deprecated Use {@link #allowedAuthenticators(int)} instead.
              */
             @NonNull
+            @Deprecated
             public Builder deviceCredentialsAllowed(boolean deviceCredentialsAllowed) {
                 this.deviceCredentialsAllowed = deviceCredentialsAllowed;
                 return this;
             }
 
-
             /**
-             * @see BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed
+             * @see BiometricPrompt.PromptInfo.Builder#setAllowedAuthenticators(int)
              */
             @NonNull
-            public Builder allowedAuthenticators(boolean deviceCredentialsAllowed) {
-                this.deviceCredentialsAllowed = deviceCredentialsAllowed;
+            public Builder allowedAuthenticators(int allowedAuthenticators) {
+                this.allowedAuthenticators = allowedAuthenticators;
                 return this;
             }
 

--- a/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
+++ b/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
@@ -149,6 +149,8 @@ class GoldfingerImpl implements Goldfinger {
             return true;
         }
 
+        // TODO add control for supported auth combination
+
         if (!hasFingerprintHardware(params.allowedAuthenticators())) {
             callback.onError(new MissingHardwareException());
             return true;

--- a/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
+++ b/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
@@ -151,8 +151,6 @@ class GoldfingerImpl implements Goldfinger {
             return true;
         }
 
-        // TODO add control for supported auth combination
-
         if (!hasFingerprintHardware(params.allowedAuthenticators())) {
             callback.onError(new MissingHardwareException());
             return true;

--- a/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
+++ b/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
@@ -64,8 +64,8 @@ class GoldfingerImpl implements Goldfinger {
     }
 
     @Override
-    public boolean canAuthenticate() {
-        return biometricManager.canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS;
+    public boolean canAuthenticate(int authenticators) {
+        return biometricManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS;
     }
 
     /**
@@ -108,13 +108,15 @@ class GoldfingerImpl implements Goldfinger {
     }
 
     @Override
-    public boolean hasEnrolledFingerprint() {
-        return biometricManager.canAuthenticate() != BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED;
+    public boolean hasEnrolledFingerprint(int authenticators) {
+        return biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
+            && biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
     }
 
     @Override
-    public boolean hasFingerprintHardware() {
-        return biometricManager.canAuthenticate() != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE;
+    public boolean hasFingerprintHardware(int authenticators) {
+        return biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+            && biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
     }
 
     private void initializeCryptoObject(
@@ -147,12 +149,12 @@ class GoldfingerImpl implements Goldfinger {
             return true;
         }
 
-        if (!hasFingerprintHardware()) {
+        if (!hasFingerprintHardware(params.allowedAuthenticators())) {
             callback.onError(new MissingHardwareException());
             return true;
         }
 
-        if (!hasEnrolledFingerprint()) {
+        if (!hasEnrolledFingerprint(params.allowedAuthenticators())) {
             callback.onError(new NoEnrolledFingerprintException());
             return true;
         }

--- a/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
+++ b/core/src/main/java/co/infinum/goldfinger/GoldfingerImpl.java
@@ -109,14 +109,16 @@ class GoldfingerImpl implements Goldfinger {
 
     @Override
     public boolean hasEnrolledFingerprint(int authenticators) {
-        return biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
-            && biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
+        int authenticationStatus = biometricManager.canAuthenticate(authenticators);
+        return authenticationStatus != BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
+            && authenticationStatus != BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
     }
 
     @Override
     public boolean hasFingerprintHardware(int authenticators) {
-        return biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
-            && biometricManager.canAuthenticate(authenticators) != BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
+        int authenticationStatus = biometricManager.canAuthenticate(authenticators);
+        return authenticationStatus != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+            && authenticationStatus != BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
     }
 
     private void initializeCryptoObject(

--- a/core/src/main/java/co/infinum/goldfinger/GoldfingerMock.java
+++ b/core/src/main/java/co/infinum/goldfinger/GoldfingerMock.java
@@ -12,7 +12,7 @@ class GoldfingerMock implements Goldfinger {
     }
 
     @Override
-    public boolean canAuthenticate() {
+    public boolean canAuthenticate(int authenticators) {
         return false;
     }
 
@@ -29,12 +29,12 @@ class GoldfingerMock implements Goldfinger {
     }
 
     @Override
-    public boolean hasEnrolledFingerprint() {
+    public boolean hasEnrolledFingerprint(int authenticators) {
         return false;
     }
 
     @Override
-    public boolean hasFingerprintHardware() {
+    public boolean hasFingerprintHardware(int authenticators) {
         return false;
     }
 }

--- a/core/src/main/java/co/infinum/goldfinger/ValidateUtils.java
+++ b/core/src/main/java/co/infinum/goldfinger/ValidateUtils.java
@@ -47,9 +47,9 @@ class ValidateUtils {
             errors.add("Title is required!");
         }
 
-        if (!params.deviceCredentialsAllowed() && StringUtils.isBlankOrNull(params.negativeButtonText())) {
-            errors.add("NegativeButtonText is required!");
-        }
+//        if (!params.deviceCredentialsAllowed() && StringUtils.isBlankOrNull(params.negativeButtonText())) {
+//            errors.add("NegativeButtonText is required!");
+//        }
 
         if (params.deviceCredentialsAllowed() && mode != Mode.AUTHENTICATION) {
             errors.add("DeviceCredentials are allowed only for Goldfinger#authenticate method.");

--- a/core/src/main/java/co/infinum/goldfinger/ValidateUtils.java
+++ b/core/src/main/java/co/infinum/goldfinger/ValidateUtils.java
@@ -47,9 +47,13 @@ class ValidateUtils {
             errors.add("Title is required!");
         }
 
-//        if (!params.deviceCredentialsAllowed() && StringUtils.isBlankOrNull(params.negativeButtonText())) {
-//            errors.add("NegativeButtonText is required!");
-//        }
+        if (params.deviceCredentialsAllowed() && !StringUtils.isBlankOrNull(params.negativeButtonText())) {
+            errors.add("Can not use NegativeButtonText and BiometricManager.Authenticators.DEVICE_CREDENTIAL");
+        }
+
+        if (!params.deviceCredentialsAllowed() && StringUtils.isBlankOrNull(params.negativeButtonText())) {
+            errors.add("NegativeButtonText is required!");
+        }
 
         if (params.deviceCredentialsAllowed() && mode != Mode.AUTHENTICATION) {
             errors.add("DeviceCredentials are allowed only for Goldfinger#authenticate method.");

--- a/core/src/test/java/co/infinum/goldfinger/ValidateUtilsTest.java
+++ b/core/src/test/java/co/infinum/goldfinger/ValidateUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import androidx.biometric.BiometricManager;
 import androidx.fragment.app.FragmentActivity;
 
 import static org.junit.Assert.assertEquals;
@@ -29,7 +30,7 @@ public class ValidateUtilsTest {
             .negativeButtonText(NEGATIVE_BUTTON_TEXT)
             .description(DESCRIPTION)
             .subtitle(SUBTITLE)
-            .deviceCredentialsAllowed(true)
+            .allowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK & BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .confirmationRequired(true)
             .build();
         assertEquals(1, ValidateUtils.validatePromptParams(Mode.AUTHENTICATION, params).size());
@@ -50,7 +51,7 @@ public class ValidateUtilsTest {
             .negativeButtonText(NEGATIVE_BUTTON_TEXT)
             .description(DESCRIPTION)
             .subtitle(SUBTITLE)
-            .deviceCredentialsAllowed(true)
+            .allowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK & BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .confirmationRequired(true)
             .build();
         assertTrue(ValidateUtils.validatePromptParams(Mode.AUTHENTICATION, params).isEmpty());
@@ -69,7 +70,7 @@ public class ValidateUtilsTest {
     public void auth_valid_negativeTextIgnoredIfDeviceCredentialsTrue() {
         Goldfinger.PromptParams params = new Goldfinger.PromptParams.Builder(activity)
             .title(TITLE)
-            .deviceCredentialsAllowed(true)
+            .allowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .build();
         assertTrue(ValidateUtils.validatePromptParams(Mode.AUTHENTICATION, params).isEmpty());
     }
@@ -88,7 +89,7 @@ public class ValidateUtilsTest {
     public void decrypt_invalid_withDeviceCredentialsTrue() {
         Goldfinger.PromptParams params = new Goldfinger.PromptParams.Builder(activity)
             .title(TITLE)
-            .deviceCredentialsAllowed(true)
+            .allowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .build();
         assertEquals(1, ValidateUtils.validatePromptParams(Mode.DECRYPTION, params).size());
     }
@@ -112,7 +113,7 @@ public class ValidateUtilsTest {
     public void encrypt_invalid_withDeviceCredentialsTrue() {
         Goldfinger.PromptParams params = new Goldfinger.PromptParams.Builder(activity)
             .title(TITLE)
-            .deviceCredentialsAllowed(true)
+            .allowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .build();
         assertEquals(1, ValidateUtils.validatePromptParams(Mode.ENCRYPTION, params).size());
     }

--- a/example/src/main/java/co/infinum/example/BaseLoginActivity.java
+++ b/example/src/main/java/co/infinum/example/BaseLoginActivity.java
@@ -44,6 +44,7 @@ public abstract class BaseLoginActivity extends AppCompatActivity {
             .title("Login")
             .description("Confirm Fingerprint to Login")
             .negativeButtonText("Cancel")
+            .allowedAuthenticators(SharedPrefs.getAuthenticators())
             .build();
     }
 

--- a/example/src/main/java/co/infinum/example/BasePaymentActivity.java
+++ b/example/src/main/java/co/infinum/example/BasePaymentActivity.java
@@ -21,7 +21,8 @@ public abstract class BasePaymentActivity extends AppCompatActivity {
             .title("Payment")
             .description("Authenticate Fingerprint to proceed with payment")
             /* Device credentials can be used here */
-            //            .deviceCredentialsAllowed(true)
+//                        .deviceCredentialsAllowed(true)
+//            .allowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK | BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .negativeButtonText("Cancel")
             .build();
     }

--- a/example/src/main/java/co/infinum/example/BasePaymentActivity.java
+++ b/example/src/main/java/co/infinum/example/BasePaymentActivity.java
@@ -20,10 +20,8 @@ public abstract class BasePaymentActivity extends AppCompatActivity {
         return new Goldfinger.PromptParams.Builder(this)
             .title("Payment")
             .description("Authenticate Fingerprint to proceed with payment")
-            /* Device credentials can be used here */
-//                        .deviceCredentialsAllowed(true)
-//            .allowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK | BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .negativeButtonText("Cancel")
+            .allowedAuthenticators(SharedPrefs.getAuthenticators())
             .build();
     }
 

--- a/example/src/main/java/co/infinum/example/BaseSettingsActivity.java
+++ b/example/src/main/java/co/infinum/example/BaseSettingsActivity.java
@@ -29,6 +29,7 @@ public abstract class BaseSettingsActivity extends AppCompatActivity {
             .title("Settings")
             .description("Confirm Fingerprint to enable Fingerprint Login")
             .negativeButtonText("Cancel")
+            .allowedAuthenticators(SharedPrefs.getAuthenticators())
             .build();
     }
 

--- a/example/src/main/java/co/infinum/example/ChooseImplementationActivity.java
+++ b/example/src/main/java/co/infinum/example/ChooseImplementationActivity.java
@@ -4,13 +4,18 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.biometric.BiometricManager;
+import co.infinum.goldfinger.Goldfinger;
 
 public class ChooseImplementationActivity extends AppCompatActivity {
 
+    private TextView strongAuthenticator;
+    private TextView weakAuthenticator;
     private View pinLoginExampleButton;
     private View pinLoginRxExampleButton;
     private View paymentExampleButton;
@@ -28,6 +33,7 @@ public class ChooseImplementationActivity extends AppCompatActivity {
         setContentView(R.layout.activity_choose_implementation);
         initViews();
         initListeners();
+        initAuthenticatorsData();
     }
 
     @RequiresApi(Build.VERSION_CODES.M)
@@ -39,10 +45,40 @@ public class ChooseImplementationActivity extends AppCompatActivity {
     }
 
     private void initViews() {
+        this.strongAuthenticator = findViewById(R.id.strongAuthenticator);
+        this.weakAuthenticator = findViewById(R.id.weakAuthenticator);
         this.pinLoginExampleButton = findViewById(R.id.pinLoginExampleButton);
         this.pinLoginRxExampleButton = findViewById(R.id.pinLoginRxExampleButton);
         this.paymentExampleButton = findViewById(R.id.paymentExampleButton);
         this.paymentRxExampleButton = findViewById(R.id.paymentRxExampleButton);
+    }
+
+    private void initAuthenticatorsData() {
+        Goldfinger goldfinger = new Goldfinger.Builder(this).build();
+
+        strongAuthenticator.setText(constructBiometricsInfoString(goldfinger, BiometricManager.Authenticators.BIOMETRIC_STRONG));
+        weakAuthenticator.setText(constructBiometricsInfoString(goldfinger, BiometricManager.Authenticators.BIOMETRIC_WEAK));
+    }
+
+    private String constructBiometricsInfoString(Goldfinger goldfinger, int authenticator) {
+        boolean hasAvailableAuthentication = goldfinger.canAuthenticate(authenticator);
+        boolean hasBiometricEnrolled = goldfinger.hasEnrolledFingerprint(authenticator);
+        boolean hasBiometricHardware = goldfinger.hasFingerprintHardware(authenticator);
+
+        StringBuilder stringBuilder = new StringBuilder(
+            String.format("Authenticator %s available", hasAvailableAuthentication ? "is" : "NOT")
+        );
+
+        if (hasAvailableAuthentication) {
+            stringBuilder.append(
+                String.format("\n - %s \n - %s",
+                    String.format("At least one biometric %s enrolled", hasBiometricEnrolled ? "is" : "NOT"),
+                    String.format("Biometrics hardware %s detected", hasBiometricHardware ? "is" : "NOT")
+                )
+            );
+        }
+
+        return stringBuilder.toString();
     }
 
     @RequiresApi(Build.VERSION_CODES.M)

--- a/example/src/main/java/co/infinum/example/ChooseImplementationActivity.java
+++ b/example/src/main/java/co/infinum/example/ChooseImplementationActivity.java
@@ -16,10 +16,15 @@ public class ChooseImplementationActivity extends AppCompatActivity {
 
     private CheckBox strongCheckBox;
     private TextView strongAuthenticator;
+
     private CheckBox weakCheckBox;
     private TextView weakAuthenticator;
+
+    private CheckBox deviceCredentialsCheckBox;
+
     private View pinLoginExampleButton;
     private View pinLoginRxExampleButton;
+
     private View paymentExampleButton;
     private View paymentRxExampleButton;
 
@@ -41,30 +46,53 @@ public class ChooseImplementationActivity extends AppCompatActivity {
     private void initListeners() {
         this.pinLoginExampleButton.setOnClickListener(v -> navigateToSetPinActivity(false));
         this.pinLoginRxExampleButton.setOnClickListener(v -> navigateToSetPinActivity(true));
+
         this.paymentExampleButton.setOnClickListener(v -> navigateToPaymentActivity(false));
         this.paymentRxExampleButton.setOnClickListener(v -> navigateToPaymentActivity(true));
+
         this.strongCheckBox.setOnCheckedChangeListener((compoundButton, b) -> updateAuthenticators());
+
         this.weakCheckBox.setOnCheckedChangeListener((compoundButton, b) -> updateAuthenticators());
+
+        this.deviceCredentialsCheckBox.setOnCheckedChangeListener((compoundButton, b) -> updateAuthenticators());
     }
 
     private void updateAuthenticators() {
         int authenticators = 0;
+
+        SharedPrefs.setStrongAuth(strongCheckBox.isChecked());
         if (strongCheckBox.isChecked()) {
             authenticators |= BiometricManager.Authenticators.BIOMETRIC_STRONG;
         }
+
+        SharedPrefs.setWeakAuth(weakCheckBox.isChecked());
         if (weakCheckBox.isChecked()) {
             authenticators |= BiometricManager.Authenticators.BIOMETRIC_WEAK;
         }
+
+        SharedPrefs.setDeviceCredentialsAuth(deviceCredentialsCheckBox.isChecked());
+        if (deviceCredentialsCheckBox.isChecked()) {
+            authenticators |= BiometricManager.Authenticators.DEVICE_CREDENTIAL;
+        }
+
         SharedPrefs.setAuthenticators(authenticators);
     }
 
     private void initViews() {
         this.strongCheckBox = findViewById(R.id.strongCheckBox);
+        this.strongCheckBox.setChecked(SharedPrefs.getStrongAuth());
         this.strongAuthenticator = findViewById(R.id.strongAuthenticator);
+
         this.weakCheckBox = findViewById(R.id.weakCheckBox);
+        this.weakCheckBox.setChecked(SharedPrefs.getWeakAuth());
         this.weakAuthenticator = findViewById(R.id.weakAuthenticator);
+
+        this.deviceCredentialsCheckBox = findViewById(R.id.deviceCredentialsCheckBox);
+        this.deviceCredentialsCheckBox.setChecked(SharedPrefs.getDeviceCredentialsAuth());
+
         this.pinLoginExampleButton = findViewById(R.id.pinLoginExampleButton);
         this.pinLoginRxExampleButton = findViewById(R.id.pinLoginRxExampleButton);
+
         this.paymentExampleButton = findViewById(R.id.paymentExampleButton);
         this.paymentRxExampleButton = findViewById(R.id.paymentRxExampleButton);
     }
@@ -74,6 +102,7 @@ public class ChooseImplementationActivity extends AppCompatActivity {
 
         strongCheckBox.setEnabled(goldfinger.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG));
         strongAuthenticator.setText(constructBiometricsInfoString(goldfinger, BiometricManager.Authenticators.BIOMETRIC_STRONG));
+
         weakCheckBox.setEnabled(goldfinger.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK));
         weakAuthenticator.setText(constructBiometricsInfoString(goldfinger, BiometricManager.Authenticators.BIOMETRIC_WEAK));
     }
@@ -107,6 +136,5 @@ public class ChooseImplementationActivity extends AppCompatActivity {
     private void navigateToSetPinActivity(boolean isRxExample) {
         SharedPrefs.setRxExample(isRxExample);
         startActivity(new Intent(this, SetPinActivity.class));
-        finish();
     }
 }

--- a/example/src/main/java/co/infinum/example/SharedPrefs.java
+++ b/example/src/main/java/co/infinum/example/SharedPrefs.java
@@ -85,6 +85,30 @@ public class SharedPrefs {
         PREFS.edit().putBoolean("isRx", isRxExample).commit();
     }
 
+    public static void setStrongAuth(boolean strongAuth) {
+        PREFS.edit().putBoolean("strongAuth", strongAuth).commit();
+    }
+
+    public static boolean getStrongAuth() {
+        return PREFS.getBoolean("strongAuth", false);
+    }
+
+    public static void setWeakAuth(boolean weakAuth) {
+        PREFS.edit().putBoolean("weakAuth", weakAuth).commit();
+    }
+
+    public static boolean getWeakAuth() {
+        return PREFS.getBoolean("weakAuth", false);
+    }
+
+    public static void setDeviceCredentialsAuth(boolean deviceCredentialsAuth) {
+        PREFS.edit().putBoolean("deviceCredentialsAuth", deviceCredentialsAuth).commit();
+    }
+
+    public static boolean getDeviceCredentialsAuth() {
+        return PREFS.getBoolean("deviceCredentialsAuth", false);
+    }
+
     public static void setAuthenticators(int authenticators) {
         PREFS.edit().putInt("authenticators", authenticators).commit();
     }

--- a/example/src/main/java/co/infinum/example/SharedPrefs.java
+++ b/example/src/main/java/co/infinum/example/SharedPrefs.java
@@ -17,7 +17,6 @@ import co.infinum.goldfinger.crypto.impl.UnlockedAesCipherFactory;
  * Encrypted Shared prefs wrapper which encrypts and decrypts PIN
  * automatically using Goldfinger's exposed API.
  */
-@RequiresApi(Build.VERSION_CODES.M)
 public class SharedPrefs {
 
     private static SharedPreferences PREFS;
@@ -28,15 +27,18 @@ public class SharedPrefs {
         PREFS.edit().clear().apply();
     }
 
+    @RequiresApi(Build.VERSION_CODES.M)
     public static void clearFingerprintPin() {
         PREFS.edit().remove("fp_pin").apply();
     }
 
+    @RequiresApi(Build.VERSION_CODES.M)
     public static String getFingerprintPin() {
         return PREFS.getString("fp_pin", null);
     }
 
     @Nullable
+    @RequiresApi(Build.VERSION_CODES.M)
     public static String getPin() {
         String encryptedPin = PREFS.getString("pin", "");
         if ("".equals(encryptedPin)) {
@@ -54,6 +56,7 @@ public class SharedPrefs {
     /**
      * Please do not do this in production.
      */
+    @RequiresApi(Build.VERSION_CODES.M)
     public static void init(Context context) {
         PREFS = context.getSharedPreferences("My awesome app prefs", Context.MODE_PRIVATE);
         CRYPTER = new Base64CipherCrypter();
@@ -80,5 +83,13 @@ public class SharedPrefs {
 
     public static void setRxExample(boolean isRxExample) {
         PREFS.edit().putBoolean("isRx", isRxExample).commit();
+    }
+
+    public static void setAuthenticators(int authenticators) {
+        PREFS.edit().putInt("authenticators", authenticators).commit();
+    }
+
+    public static int getAuthenticators() {
+        return PREFS.getInt("authenticators", 0);
     }
 }

--- a/example/src/main/res/layout/activity_choose_implementation.xml
+++ b/example/src/main/res/layout/activity_choose_implementation.xml
@@ -64,6 +64,31 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/deviceCredentialsCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Device Credentials "
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/deviceCredentialsAuthenticator"
+            android:layout_width="wrap_content"
+            android:paddingBottom="8dp"
+            android:layout_height="wrap_content"/>
+
+    </LinearLayout>
+
     <TextView
         android:id="@+id/examples"
         android:layout_width="wrap_content"

--- a/example/src/main/res/layout/activity_choose_implementation.xml
+++ b/example/src/main/res/layout/activity_choose_implementation.xml
@@ -3,42 +3,101 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
+    android:gravity="center_vertical"
     android:orientation="vertical">
 
     <TextView
-        android:id="@+id/paymentExampleButton"
-        style="@style/Button"
-        android:layout_width="200dp"
+        android:id="@+id/availableAuthenticators"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Payment example"
-        />
+        android:layout_marginHorizontal="16dp"
+        android:text="Available authenticators:"
+        android:textStyle="bold"/>
 
     <TextView
-        android:id="@+id/paymentRxExampleButton"
-        style="@style/Button"
-        android:layout_width="200dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="Payment Rx example"
-        />
+        android:layout_marginHorizontal="16dp"
+        android:text="Strong"
+        android:textStyle="bold"/>
 
     <TextView
-        android:id="@+id/pinLoginExampleButton"
-        style="@style/Button"
-        android:layout_width="200dp"
+        android:id="@+id/strongAuthenticator"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="Pin Login example"
-        />
+        android:layout_marginHorizontal="16dp"/>
 
     <TextView
-        android:id="@+id/pinLoginRxExampleButton"
-        style="@style/Button"
-        android:layout_width="200dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="16dp"
+        android:text="Weak"
+        android:textStyle="bold"/>
+
+    <TextView
+        android:id="@+id/weakAuthenticator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"/>
+
+    <TextView
+        android:id="@+id/examples"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
         android:layout_marginTop="32dp"
-        android:text="Pin Login Rx Example"
-        />
+        android:text="Examples:"
+        android:textStyle="bold"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/paymentExampleButton"
+            style="@style/Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_weight="1"
+            android:text="Payment"/>
+
+        <TextView
+            android:id="@+id/pinLoginExampleButton"
+            style="@style/Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_weight="1"
+            android:text="Pin Login"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/paymentRxExampleButton"
+            style="@style/Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_weight="1"
+            android:text="Payment Rx"/>
+
+        <TextView
+            android:id="@+id/pinLoginRxExampleButton"
+            style="@style/Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_weight="1"
+            android:text="Pin Login Rx"/>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/example/src/main/res/layout/activity_choose_implementation.xml
+++ b/example/src/main/res/layout/activity_choose_implementation.xml
@@ -14,32 +14,55 @@
         android:text="Available authenticators:"
         android:textStyle="bold"/>
 
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
-        android:text="Strong"
-        android:textStyle="bold"/>
+        android:orientation="horizontal">
 
-    <TextView
-        android:id="@+id/strongAuthenticator"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"/>
+        <CheckBox
+            android:id="@+id/strongCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
 
-    <TextView
-        android:layout_width="wrap_content"
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Strong "
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/strongAuthenticator"
+            android:layout_width="wrap_content"
+            android:paddingBottom="8dp"
+            android:layout_height="wrap_content"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:layout_marginHorizontal="16dp"
-        android:text="Weak"
-        android:textStyle="bold"/>
+        android:orientation="horizontal">
 
-    <TextView
-        android:id="@+id/weakAuthenticator"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"/>
+        <CheckBox
+            android:id="@+id/weakCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Weak "
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/weakAuthenticator"
+            android:layout_width="wrap_content"
+            android:paddingBottom="8dp"
+            android:layout_height="wrap_content"/>
+
+    </LinearLayout>
 
     <TextView
         android:id="@+id/examples"

--- a/rx/src/main/java/co/infinum/goldfinger/rx/RxGoldfinger.java
+++ b/rx/src/main/java/co/infinum/goldfinger/rx/RxGoldfinger.java
@@ -17,19 +17,19 @@ import io.reactivex.Observable;
 public interface RxGoldfinger {
 
     /**
-     * @see Goldfinger#canAuthenticate
+     * @see Goldfinger#canAuthenticate(int)
      */
-    boolean canAuthenticate();
+    boolean canAuthenticate(int authenticators);
 
     /**
-     * @see Goldfinger#hasFingerprintHardware
+     * @see Goldfinger#hasFingerprintHardware(int)
      */
-    boolean hasFingerprintHardware();
+    boolean hasFingerprintHardware(int authenticators);
 
     /**
-     * @see Goldfinger#hasEnrolledFingerprint
+     * @see Goldfinger#hasEnrolledFingerprint(int)
      */
-    boolean hasEnrolledFingerprint();
+    boolean hasEnrolledFingerprint(int authenticators);
 
     /**
      * @see Goldfinger#authenticate

--- a/rx/src/main/java/co/infinum/goldfinger/rx/RxGoldfingerImpl.java
+++ b/rx/src/main/java/co/infinum/goldfinger/rx/RxGoldfingerImpl.java
@@ -29,8 +29,8 @@ class RxGoldfingerImpl implements RxGoldfinger {
     }
 
     @Override
-    public boolean canAuthenticate() {
-        return goldfinger.canAuthenticate();
+    public boolean canAuthenticate(int authenticators) {
+        return goldfinger.canAuthenticate(authenticators);
     }
 
     @Override
@@ -72,12 +72,12 @@ class RxGoldfingerImpl implements RxGoldfinger {
     }
 
     @Override
-    public boolean hasEnrolledFingerprint() {
-        return goldfinger.hasEnrolledFingerprint();
+    public boolean hasEnrolledFingerprint(int authenticators) {
+        return goldfinger.hasEnrolledFingerprint(authenticators);
     }
 
     @Override
-    public boolean hasFingerprintHardware() {
-        return goldfinger.hasFingerprintHardware();
+    public boolean hasFingerprintHardware(int authenticators) {
+        return goldfinger.hasFingerprintHardware(authenticators);
     }
 }


### PR DESCRIPTION
This PR adds support for specifying authenticator types when doing biometric operations. The biometric lib supports 3 auth types:

- BIOMETRIC_STRONG - Any biometric (e.g. fingerprint, iris, or face) on the device that meets or exceeds the requirements for Class 3 (formerly Strong), as defined by the Android CDD.
- BIOMETRIC_WEAK - Any biometric (e.g. fingerprint, iris, or face) on the device that meets or exceeds the requirements for Class 2 (formerly Weak), as defined by the Android CDD.
- DEVICE_CREDENTIAL - The non-biometric credential used to secure the device (i.e. PIN, pattern, or password). 

The new main screen of the example app now displays the appropriate information about each of these authenticators. The specific authenticator is disabled enabled depending on the device support for that authenticator type.

![Screenshot_20210407_113751_co infinum goldfinger example](https://user-images.githubusercontent.com/3235951/113845520-e69e7e00-9795-11eb-8b9e-a61a084e9e00.jpg)


Alongside these changes the new version includes a new `Reason` type that is dispatched in the `onResult` callback - `SECURITY_UPDATE_REQUIRED`. This is dispatched in case a security update is needed. Documentation ref:
> A security vulnerability has been discovered with one or more hardware sensors. The
> affected sensor(s) are unavailable until a security update has addressed the issue.