### PR TITLE
Change namespace to com.infinum

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ buildscript {
 #### Add dependency
 
 ```gradle
-implementation 'co.infinum:goldfinger:2.2.0'
+implementation 'com.infinum:goldfinger:2.2.0'
 ```
 
 #### Initialize
@@ -80,8 +80,8 @@ Goldfinger has separate Rx module in case you want to use reactive approach.
 #### Add dependencies
 
 ```gradle
-implementation 'co.infinum:goldfinger:2.2.0'
-implementation 'co.infinum:goldfinger-rx:2.2.0'
+implementation 'com.infinum:goldfinger:2.2.0'
+implementation 'com.infinum:goldfinger-rx:2.2.0'
 ```
 
 #### Initialize

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     ]
 
     ext.releaseConfig = [
-        "groupId"   : 'co.infinum',
+        "groupId"   : 'com.infinum',
     ]
 
     repositories {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -21,6 +21,6 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxjava:${versions.rxjava}"
     implementation project(':core')
     implementation project(':rx')
-//    implementation "co.infinum:goldfinger:${versions.goldfinger}"
-//    implementation "co.infinum:goldfinger-rx:${versions.goldfinger}"
+//    implementation "com.infinum:goldfinger:${versions.goldfinger}"
+//    implementation "com.infinum:goldfinger-rx:${versions.goldfinger}"
 }

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -13,8 +13,8 @@ task generateReadme {
     doFirst {
         def readmeFile = new File("${project.rootDir}/README.md")
         def content = readmeFile.text
-        content = content.replaceAll("'co\\.infinum:goldfinger:.+?'", "'co.infinum:goldfinger:${versions.goldfinger}'")
-        content = content.replaceAll("'co\\.infinum:goldfinger-rx?:.+?'", "'co.infinum:goldfinger-rx:${versions.goldfinger}'")
+        content = content.replaceAll("'com\\.infinum:goldfinger:.+?'", "'com.infinum:goldfinger:${versions.goldfinger}'")
+        content = content.replaceAll("'com\\.infinum:goldfinger-rx?:.+?'", "'com.infinum:goldfinger-rx:${versions.goldfinger}'")
         readmeFile.setText(content)
     }
 }


### PR DESCRIPTION
I have updated the namespace to 'com.infinum'. Please verify that there is no other place that still uses the 'co.infinum' namespace.

One dilemma here is I should rename the package name from 'co.infinum.goldfinger' to 'com.infinum.goldfinger'. The same goes for the example app 'co.infinum.example' to 'com.infinum.example'. Since the example app is not published anywhere and we use it only to test the library, I guess it doesn't matter. And for the library, I think we should change it so that the imports don't look like this: 
`import co.infinum.goldfinger.Goldfinger`

What do you think @margaritajankovska @KCeh 